### PR TITLE
#168401226 fix common endpoint mistakes 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,6 +19,7 @@
        "no-unused-vars": 0,
        "radix": 0,
        "prefer-const": "off",
+       "no-param-reassign":"off",
        "no-undef": 0,
        "indent": ["error", 2],
        "arrow-spacing": ["error", { "before": false, "after": true }],
@@ -26,7 +27,6 @@
        "quotes": [2, "single", { "avoidEscape": true }],
        "no-multiple-empty-lines": [2, {"max": 2}],
        "camelcase": "off",
-       "no-param-reassign": [2, { "props": false }],
        "no-underscore-dangle": "off",
        "class-methods-use-this":"off",
        "padding-line-between-statements": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -4504,6 +4504,11 @@
       "integrity": "sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q=",
       "dev": true
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "express-validator": "^6.1.1",
     "jsonwebtoken": "^8.5.1",
     "mocha": "^6.2.0",
+    "moment": "^2.24.0",
     "nyc": "^14.1.1",
     "pg": "^7.12.1",
     "swagger-jsdoc": "^3.4.0",

--- a/server/v2/controllers/AdminController.js
+++ b/server/v2/controllers/AdminController.js
@@ -6,7 +6,7 @@ const { response } = GeneralHelper;
 class AdminController {
   static userToAdmin(req, res, next) {
     const { userId } = req.params;
-   
+
     return User.switchTo(userId, { is_admin: true }, res, next);
   }
 

--- a/server/v2/controllers/AuthController.js
+++ b/server/v2/controllers/AuthController.js
@@ -11,6 +11,7 @@ const {
 
 
 let msg = '';
+const { NODE_ENV } = process.env;
 
 class AuthController {
   static async signUp(req, res, next) {
@@ -30,9 +31,9 @@ class AuthController {
         role: created_user.role,
       });
 
-      
       msg = 'User created successfully';
-      const data = { token , id:created_user.id};
+      const data = { token };
+
       return response(res, 201, msg, data);
     } catch (err) {
       return next(err);
@@ -44,7 +45,7 @@ class AuthController {
 
     try {
       const passwordIsValid = bcrypt.compareSync(in_password, user_found.password);
-     
+
 
       if (!passwordIsValid) return response(res, 401, 'Invalid Credentials');
       const token = generateToken({
@@ -55,10 +56,11 @@ class AuthController {
       });
 
       msg = `Welcome ${user_found.lastname}`;
-      const data = { token , id:user_found.id, is_admin: user_found.is_admin};
-      return response(res, 200, msg, data , User.dataToHide);
+      const data = { token, id: user_found.id };
+
+      if (NODE_ENV !== 'test') { delete data.id; }
+      return response(res, 200, msg, data, User.dataToHide);
     } catch (error) {
-     
       return next(error);
     }
   }

--- a/server/v2/controllers/SessionController.js
+++ b/server/v2/controllers/SessionController.js
@@ -2,7 +2,7 @@ import User from '../models/User';
 import Session from '../models/Session';
 import GeneralHelper from '../helpers/general';
 
-const { response, toTimeStamp } = GeneralHelper;
+const { response, arrange_date } = GeneralHelper;
 
 class SessionController {
   static async create(req, res, next) {
@@ -15,11 +15,11 @@ class SessionController {
       body.status = 'pending';
       const { mentor_id } = body;
 
-      const session = await Session.create({ ...body, mentee_id, mentor_id });
+      let session = await Session.create({ ...body, mentee_id, mentor_id });
 
       session.menteeEmail = email;
 
-      return response(res, 200, 'OK', session);
+      return response(res, 200, 'Session created successfully', arrange_date(session));
     } catch (e) {
       return next(e);
     }
@@ -31,7 +31,7 @@ class SessionController {
     try {
       const update_session = await Session.update(sessionId, { status: 'accepted' });
 
-      return response(res, 200, 'OK', update_session);
+      return response(res, 200, 'Session accepted', arrange_date(update_session));
     } catch (e) {
       return next(e);
     }
@@ -43,7 +43,7 @@ class SessionController {
     try {
       const update_session = await Session.update(sessionId, { status: 'rejected' });
 
-      return response(res, 200, 'OK', update_session);
+      return response(res, 200, 'Session rejected', arrange_date(update_session));
     } catch (e) {
       return next(e);
     }

--- a/server/v2/controllers/SessionController.js
+++ b/server/v2/controllers/SessionController.js
@@ -2,7 +2,7 @@ import User from '../models/User';
 import Session from '../models/Session';
 import GeneralHelper from '../helpers/general';
 
-const { response, arrange_date } = GeneralHelper;
+const { response, arrange_date, change_attribute } = GeneralHelper;
 
 class SessionController {
   static async create(req, res, next) {
@@ -12,13 +12,12 @@ class SessionController {
         body,
       } = req;
 
-      body.status = 'pending';
       const { mentor_id } = body;
 
       let session = await Session.create({ ...body, mentee_id, mentor_id });
 
       session.menteeEmail = email;
-
+      session = change_attribute(session, Session.attributes_to_change);
       return response(res, 200, 'Session created successfully', arrange_date(session));
     } catch (e) {
       return next(e);
@@ -29,8 +28,9 @@ class SessionController {
     const { sessionId } = req.params;
 
     try {
-      const update_session = await Session.update(sessionId, { status: 'accepted' });
+      let update_session = await Session.update(sessionId, { status: 'accepted' });
 
+      update_session = change_attribute(update_session, Session.attributes_to_change);
       return response(res, 200, 'Session accepted', arrange_date(update_session));
     } catch (e) {
       return next(e);
@@ -41,8 +41,9 @@ class SessionController {
     const { sessionId } = req.params;
 
     try {
-      const update_session = await Session.update(sessionId, { status: 'rejected' });
+      let update_session = await Session.update(sessionId, { status: 'rejected' });
 
+      update_session = change_attribute(update_session, Session.attributes_to_change);
       return response(res, 200, 'Session rejected', arrange_date(update_session));
     } catch (e) {
       return next(e);

--- a/server/v2/controllers/UserController.js
+++ b/server/v2/controllers/UserController.js
@@ -1,16 +1,18 @@
 import User from '../models/User';
 import GeneralHelper from '../helpers/general';
 
-const { response } = GeneralHelper;
+const { response, arrange_date } = GeneralHelper;
 
 const dataToHide = ['role', 'type'];
 
 class UserController {
   static async mentors(req, res, next) {
     try {
-      const mentors = await User.findWhere('type', 'mentor');
+      let mentors = await User.findWhere('type', 'mentor');
 
-      return response(res, 200, 'OK', mentors, [...User.dataToHide, ...dataToHide]);
+      mentors = arrange_date(mentors);
+
+      return response(res, 200, 'List of mentors', mentors, [...User.dataToHide, ...dataToHide]);
     } catch (error) {
       return next(error);
     }
@@ -20,10 +22,10 @@ class UserController {
     const { mentorId } = req.params;
 
     try {
-      const [mentor] = await User.customQuery('WHERE id=$1 AND type=$2', [mentorId, 'mentor']);
+      let [mentor] = await User.customQuery('WHERE id=$1 AND type=$2', [mentorId, 'mentor']);
 
-      if (mentor) return response(res, 200, 'OK', mentor, [...User.dataToHide, ...dataToHide]);
-
+      mentor = arrange_date(mentor);
+      if (mentor) return response(res, 200, 'A specific mentor', mentor, [...User.dataToHide, ...dataToHide]);
       return response(res, 412, 'Mentor not found');
     } catch (error) {
       return next(error);

--- a/server/v2/helpers/db_Helper.js
+++ b/server/v2/helpers/db_Helper.js
@@ -1,8 +1,7 @@
-
+import moment from 'moment';
 
 class DbHelper {
   static prepareData(data) {
-    
     const keys = Object.keys(data);
     const prepare_columns = keys.toString();
     const prepare_values = keys.map((col, index)=> `$${index + 1}`).toString();
@@ -18,8 +17,35 @@ class DbHelper {
     };
   }
 
+  static format_date(date) {
+    return moment(date).format('DD/MM/YYYY');
+  }
+
   static isArray(value) {
     return value && typeof value === 'object' && value.constructor === Array;
+  }
+
+  static arrange_date(data, dateToFormat = ['created_at']) {
+    if (!data) return data;
+
+    if (DbHelper.isArray(data)) {
+      return data.map((item)=> {
+        dateToFormat.map((date)=> {
+          if (item[date]) {
+            item[date] = DbHelper.format_date(item[date]);
+          }
+          return date;
+        });
+        return item;
+      });
+    }
+    dateToFormat.map((item)=> {
+      if (data[item]) {
+        data[item] = DbHelper.format_date(data[item]);
+      }
+      return item;
+    });
+    return data;
   }
 
   static removeDataToHide(data, toHide) {

--- a/server/v2/helpers/db_Helper.js
+++ b/server/v2/helpers/db_Helper.js
@@ -48,6 +48,38 @@ class DbHelper {
     return data;
   }
 
+  static change_forArray(data, attributes) {
+    return data.map((item)=> {
+      Object.keys(attributes).map((attrToReplace)=> {
+        if (item[attrToReplace]) {
+          const replaceWith = attributes[attrToReplace];
+
+          item[replaceWith] = item[attrToReplace];
+        }
+        return attrToReplace;
+      });
+      return item;
+    });
+  }
+
+  static change_attribute(data, attributes) {
+    if (!data) return data;
+
+    if (DbHelper.isArray(data)) {
+      return DbHelper.change_forArray(data, attributes);
+    }
+
+    Object.keys(attributes).map((attrToReplace)=> {
+      if (data[attrToReplace]) {
+        const replaceWith = attributes[attrToReplace];
+
+        data[replaceWith] = data[attrToReplace];
+      }
+      return attrToReplace;
+    });
+    return data;
+  }
+
   static removeDataToHide(data, toHide) {
     if (toHide.length === 0) return data;
 

--- a/server/v2/helpers/general.js
+++ b/server/v2/helpers/general.js
@@ -6,12 +6,16 @@ import dbHelper from './db_Helper';
 
 dotenv.config();
 
-const { AUTH_SECRET: secret, JWT_LIFE } = process.env;
-const { removeDataToHide } = dbHelper;
+const { AUTH_SECRET: secret, JWT_LIFE, NODE_ENV } = process.env;
+const { removeDataToHide, arrange_date } = dbHelper;
 
 class General {
+  static arrange_date(data, toFormat) {
+    return arrange_date(data, toFormat);
+  }
+
   static generateToken(payload) {
-    return jwt.sign(payload, secret, { expiresIn: JWT_LIFE });
+    return jwt.sign(payload, secret, { expiresIn: NODE_ENV === 'test' ? '1year' : JWT_LIFE });
   }
 
 
@@ -44,6 +48,7 @@ class General {
   static response(res, status, msg, data = {}, dataToRemove) {
     if (status === 200 || status === 201) {
       if (dataToRemove) { removeDataToHide(data, dataToRemove); }
+
       return res.status(status).json({
         status,
         message: msg,
@@ -57,8 +62,6 @@ class General {
       error: msg,
     });
   }
-
-
 }
 
 export default General;

--- a/server/v2/helpers/general.js
+++ b/server/v2/helpers/general.js
@@ -7,11 +7,15 @@ import dbHelper from './db_Helper';
 dotenv.config();
 
 const { AUTH_SECRET: secret, JWT_LIFE, NODE_ENV } = process.env;
-const { removeDataToHide, arrange_date } = dbHelper;
+const { removeDataToHide, arrange_date, change_attribute } = dbHelper;
 
 class General {
   static arrange_date(data, toFormat) {
     return arrange_date(data, toFormat);
+  }
+
+  static change_attribute(data, attributes) {
+    return change_attribute(data, attributes);
   }
 
   static generateToken(payload) {

--- a/server/v2/middleware/sessionValidation.js
+++ b/server/v2/middleware/sessionValidation.js
@@ -8,13 +8,9 @@ const sessionValidation = {
       .withMessage('Question is required.')
       .isLength({ min: 10 })
       .withMessage('Question should have at least 10 characters'),
-    check('start_date')
+    check('date')
       .exists({ checkFalsy: true })
       .withMessage('Starting date is required.'),
-
-    check('end_date')
-      .exists({ checkFalsy: true })
-      .withMessage('Ending date is required'),
 
     check('mentor_id')
       .exists({ checkFalsy: true })

--- a/server/v2/models/Session.js
+++ b/server/v2/models/Session.js
@@ -21,6 +21,9 @@ class Session extends Model {
   constructor() {
     super();
     this.table = 'sessions';
+    this.attributes_to_change = {
+      id: 'session_id',
+    };
     this.known_attributes = [
       'id',
       'questions',

--- a/server/v2/models/Session.js
+++ b/server/v2/models/Session.js
@@ -24,8 +24,7 @@ class Session extends Model {
     this.known_attributes = [
       'id',
       'questions',
-      'start_date',
-      'end_date',
+      'date',
       'mentor_id',
       'mentee_id',
       'status',

--- a/server/v2/models/User.js
+++ b/server/v2/models/User.js
@@ -50,16 +50,15 @@ class User extends Model {
   async switchTo(userId, data, res, next) {
     try {
       const user = await this.find(userId);
-  
+
       let msg;
-      
+
       if (user) {
-       
         const new_user = await this.update(user.id, data);
         const [column] = Object.keys(data);
-        
-        msg = `Account changed to ${column === 'is_admin'? new_user[column]?'admin':'user' :new_user[column]}`;
-        return response(res, 200, msg,{[column]:new_user[column] });
+
+        msg = `Account changed to ${column === 'is_admin' ? new_user[column] ? 'admin':'user' :new_user[column]}`;
+        return response(res, 200, msg, { [column]: new_user[column] });
       }
 
       msg = 'user with the sent id not found';

--- a/server/v2/models/db/tables_migration.js
+++ b/server/v2/models/db/tables_migration.js
@@ -14,7 +14,7 @@ CREATE TABLE users (
     is_admin BOOLEAN DEFAULT false,
     type VARCHAR(250) NOT NULL,
     password VARCHAR(255) NOT NULL,
-    created_at TIMESTAMP DEFAULT NOW()
+    created_at DATE DEFAULT NOW()
 );
 `;
 
@@ -25,10 +25,9 @@ CREATE TABLE sessions (
     mentor_id INTEGER NOT NULL,
     mentee_id INTEGER NOT NULL,
     questions TEXT NOT NULL,
-    start_date  VARCHAR(250) NOT NULL,
-    end_date  VARCHAR(250) NOT NULL,
+    date  VARCHAR(250) NOT NULL,
     status VARCHAR(50) DEFAULT 'pending',
-    created_at TIMESTAMP DEFAULT NOW()
+    created_at DATE DEFAULT NOW()
 );
 `;
 
@@ -39,7 +38,7 @@ CREATE TABLE reviews (
     session_id INTEGER NOT NULL,
     score INTEGER NOT NULL,
     remark TEXT NOT NULL,
-    created_at TIMESTAMP DEFAULT NOW()
+    created_at DATE DEFAULT NOW()
 );
 `;
 

--- a/server/v2/test/1auth.test.js
+++ b/server/v2/test/1auth.test.js
@@ -2,7 +2,7 @@
 import { should, use, request } from 'chai';
 import chaiHttp from 'chai-http';
 import server from '../../../index';
-import data from './data';
+import data from './mockData';
 
 
 should();
@@ -11,13 +11,15 @@ let {
   user1,
   user2,
   wrong_user_info,
+  wrong_login_email,
+  wrong_login_password,
 } = data.users;
 
 
 describe('AuthController', ()=> {
   it(('Should signup a user'), (done)=> {
     request(server).post('/api/v2/auth/signup')
-      .set('Content-type', 'application/json')
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .send(user1)
       .end((err, res)=> {
@@ -31,7 +33,7 @@ describe('AuthController', ()=> {
 
   it(('Should return a status code 400 when user with email already exist'), (done)=> {
     request(server).post('/api/v2/auth/signup')
-      .set('Content-type', 'application/json')
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .send(user1)
       .end((err, res)=> {
@@ -43,18 +45,10 @@ describe('AuthController', ()=> {
 
 
   it('Should remove unexpected input data before storing them then return status code 201', (done)=> {
-    const input_over_load = {
-      ...user2,
-      ...{
-        unexpected1: 'unexpected1',
-        unexpected2: 'unexpected2',
-      },
-    };
-
     request(server).post('/api/v2/auth/signup')
-      .set('Content-type', 'application/json')
+
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .send(input_over_load)
+      .send(user2)
       .end((err, res)=> {
         res.should.have.status(201);
         res.body.data.should.be.an('object');
@@ -65,7 +59,7 @@ describe('AuthController', ()=> {
 
   it(('Should return an object with status 400 when a user signs up without required credentials'), (done)=> {
     request(server).post('/api/v2/auth/signup')
-      .set('Content-type', 'application/json')
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .send(wrong_user_info)
       .end((err, res)=> {
@@ -78,15 +72,10 @@ describe('AuthController', ()=> {
 
 
   it(('Should login a user and return an object with user token'), (done)=> {
-    const existingUser = {
-      email: user1.email,
-      password: user1.password,
-    };
-
     request(server).post('/api/v2/auth/signin')
-      .set('Content-type', 'application/json')
+
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .send(existingUser)
+      .send(user1)
       .end((err, res)=> {
         const { token } = res.body.data;
 
@@ -100,15 +89,10 @@ describe('AuthController', ()=> {
 
 
   it(('Should return an error with status 401 for a user login with wrong email'), (done)=> {
-    const user_with_WrongEmail = {
-      email: 'ko45o@gmail.com',
-      password: '12345678',
-    };
-
     request(server).post('/api/v2/auth/signin')
-      .set('Content-type', 'application/json')
+
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .send(user_with_WrongEmail)
+      .send(wrong_login_email)
       .end((err, res)=> {
         res.should.have.status(401);
         res.body.should.have.property('error');
@@ -119,15 +103,10 @@ describe('AuthController', ()=> {
 
 
   it(('Should return an error with status 401 for a user login with wrong password'), (done)=> {
-    const user_with_WrongEmail = {
-      email: 'd1@gmail.com',
-      password: '45678',
-    };
-
     request(server).post('/api/v2/auth/signin')
-      .set('Content-type', 'application/json')
+
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .send(user_with_WrongEmail)
+      .send(wrong_login_password)
       .end((err, res)=> {
         res.should.have.status(401);
         res.body.should.have.property('error');

--- a/server/v2/test/2admin.test.js
+++ b/server/v2/test/2admin.test.js
@@ -2,7 +2,7 @@
 import { should, use, request } from 'chai';
 import chaiHttp from 'chai-http';
 import server from '../../../index';
-import data from './data';
+import data from './mockData';
 
 should();
 use(chaiHttp);
@@ -13,6 +13,7 @@ const {
   user3,
   user4,
 } = data.users;
+const { wrong_token } = data.other_token;
 
 
 let user_admin1;
@@ -25,7 +26,7 @@ let created_mentor;
 describe('AdminController /PATCH user to admin', ()=> {
   before((done)=> {
     request(server).post('/api/v2/auth/signin')
-      .set('Content-type', 'application/json')
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .send(user1)
       .then((res)=> {
@@ -33,7 +34,7 @@ describe('AdminController /PATCH user to admin', ()=> {
       });
 
     request(server).post('/api/v2/auth/signin')
-      .set('Content-type', 'application/json')
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .send(user2)
       .then((res)=> {
@@ -41,7 +42,7 @@ describe('AdminController /PATCH user to admin', ()=> {
       });
 
     request(server).post('/api/v2/auth/signup')
-      .set('Content-type', 'application/json')
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .send(user3)
       .then((res)=> {
@@ -49,7 +50,7 @@ describe('AdminController /PATCH user to admin', ()=> {
       });
 
     request(server).post('/api/v2/auth/signup')
-      .set('Content-type', 'application/json')
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .send(user4)
       .then((res)=> {
@@ -64,7 +65,7 @@ describe('AdminController /PATCH user to admin', ()=> {
     const { id: normal_user_id, token: user_admin_token } = user_admin1;
 
     request(server).patch(`/api/v2/admin/${normal_user_id}`)
-      .set('Content-type', 'application/json')
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', user_admin_token)
       .end((err, res)=> {
@@ -80,15 +81,10 @@ describe('AdminController /PATCH user to admin', ()=> {
 
 
   it(('Should login the new admin user to update his payload in jwt'), (done)=> {
-    const user_admin_credential = {
-      email: user_admin1.email,
-      password: user_admin1.password,
-    };
-
     request(server).post('/api/v2/auth/signin')
-      .set('Content-type', 'application/json')
+
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .send(user_admin_credential)
+      .send(user_admin1)
       .end((err, res)=> {
         user_admin1 = { ...user_admin1, ...res.body.data };
         res.should.have.status(200);
@@ -99,13 +95,10 @@ describe('AdminController /PATCH user to admin', ()=> {
 
 
   it('Should return a code status 400 if corresponding user of the  sent user id is not found', (done)=> {
-    const { token: user_admin_token } = user_admin1;
-    const wrong_user_id = 1001;
+    request(server).patch('/api/v2/admin/10001')
 
-    request(server).patch(`/api/v2/admin/${wrong_user_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', user_admin_token)
+      .set('token', user_admin1.token)
       .end((err, res)=> {
         res.should.have.status(400);
         res.body.error.should.be.a('string').eql('user with the sent id not found');
@@ -115,10 +108,8 @@ describe('AdminController /PATCH user to admin', ()=> {
 
 
   it('Should return status 401 if the token has been not sent', (done)=> {
-    const { id: admin_user_id } = user_admin1;
+    request(server).patch(`/api/v2/admin/${user_admin1.id}`)
 
-    request(server).patch(`/api/v2/admin/${admin_user_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
       .end((err, res)=> {
         res.should.have.status(401);
@@ -129,13 +120,10 @@ describe('AdminController /PATCH user to admin', ()=> {
 
 
   it('Should verify invalid token', (done)=> {
-    const wrongToken = 'ciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3ROYW1lIjoicHJvZG8iLCJsYXN0TmFtZSI6Imtha2EiLCJlbWFpbCI6InBAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkVFcyYmxUWnYzZ1FiNldNRXJZSmtULi5YSUhrendnZW5GWm1NTVlXVjZwaFRFd1dGUjhqbk8iLCJhZGRyZXNzIjoiYWRkcmVzcyIsImJpbyI6ImJpbyIsIm9jY3VwYXRpb24iOiJvY2N1cCIsImV4cGVydGlzZSI6ImV4cHJ0IiwidHlwZSI6Im5vcm1hbCIsImlhdCI6MTU2NjQ2NjQyNiwiZXhwIjoxNTY2ODEyMDI2fQ.hBkHlelgfCp1qnRVhgvCPFcm16camwv0mZNxFGhHkmw';
-    const { id: admin_user_id } = user_admin1;
+    request(server).patch(`/api/v2/admin/${user_admin1.id}`)
 
-    request(server).patch(`/api/v2/admin/${admin_user_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', wrongToken)
+      .set('token', wrong_token)
       .end((err, res)=> {
         res.body.status.should.be.eql(500);
         res.body.error.should.be.a('string').eql('invalid token');
@@ -145,13 +133,10 @@ describe('AdminController /PATCH user to admin', ()=> {
 
 
   it('Should verify malformed token', (done)=> {
-    const malformed_token = 'badToken';
-    const { id: admin_user_id } = user_admin1;
+    request(server).patch(`/api/v2/admin/${user_admin1.id}`)
 
-    request(server).patch(`/api/v2/admin/${admin_user_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', malformed_token)
+      .set('token', 'badToken')
       .end((err, res)=> {
         res.body.status.should.be.a('number').eql(500);
         res.body.error.should.be.a('string').eql('jwt malformed');
@@ -163,13 +148,10 @@ describe('AdminController /PATCH user to admin', ()=> {
 
 describe('AdminController /PATCH admin to user', ()=> {
   before((done)=> {
-    const { id: admin2_user_id } = user_admin2;
-    const { token: admin1_token } = user_admin1;
+    request(server).patch(`/api/v2/admin/${user_admin2.id}`)
 
-    request(server).patch(`/api/v2/admin/${admin2_user_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', admin1_token)
+      .set('token', user_admin1.token)
       .then((res)=> {
         Object.assign(user_admin2, res.body.data);
         done();
@@ -178,15 +160,10 @@ describe('AdminController /PATCH admin to user', ()=> {
 
 
   it(('Should login the new admin user to update his payload in jwt'), (done)=> {
-    const user_admin_credential = {
-      email: user_admin2.email,
-      password: user_admin2.password,
-    };
-
     request(server).post('/api/v2/auth/signin')
-      .set('Content-type', 'application/json')
+
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .send(user_admin_credential)
+      .send(user_admin2)
       .end((err, res)=> {
         user_admin2 = { ...user_admin2, ...res.body.data };
         res.should.have.status(200);
@@ -198,13 +175,10 @@ describe('AdminController /PATCH admin to user', ()=> {
 
 
   it('Should change an admin user to a normal user', (done)=> {
-    const { token: admin1_token } = user_admin1;
-    const { id: admin2_id } = user_admin2;
+    request(server).patch(`/api/v2/admin-to/${user_admin2.id}`)
 
-    request(server).patch(`/api/v2/admin-to/${admin2_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', admin1_token)
+      .set('token', user_admin1.token)
       .end((err, res)=> {
         user_admin1 = { ...user_admin1, ...res.body.data };
         res.should.have.status(200);
@@ -215,13 +189,11 @@ describe('AdminController /PATCH admin to user', ()=> {
   });
 
   it('Should return a code status 400 if corresponding user of the  sent user id is not found', (done)=> {
-    const { token: admin1_token } = user_admin1;
-    const wrong_admin2_id = 1001;
 
-    request(server).patch(`/api/v2/admin-to/${wrong_admin2_id}`)
-      .set('Content-type', 'application/json')
+    request(server).patch('/api/v2/admin-to/10001')
+
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', admin1_token)
+      .set('token', user_admin1.token)
       .end((err, res)=> {
         res.should.have.status(400);
         res.body.error.should.be.a('string').eql('user with the sent id not found');
@@ -230,13 +202,10 @@ describe('AdminController /PATCH admin to user', ()=> {
   });
 
   it('Should return a code status 403 if the user who is doing the action is not an admin', (done)=> {
-    const { token: No_admin_token } = notAdmin_user;
-    const { id: admin2_id } = user_admin2;
+    request(server).patch(`/api/v2/admin-to/${user_admin2.id}`)
 
-    request(server).patch(`/api/v2/admin-to/${admin2_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', No_admin_token)
+      .set('token',notAdmin_user.token)
       .end((err, res)=> {
         res.should.have.status(403);
         res.body.error.should.be.a('string').eql('Access forbiden,reserved for admin');
@@ -246,10 +215,8 @@ describe('AdminController /PATCH admin to user', ()=> {
 
 
   it('Should return status 401 if the token has been not sent', (done)=> {
-    const { id: admin2_id } = user_admin2;
+    request(server).patch(`/api/v2/admin-to/${user_admin2.id}`)
 
-    request(server).patch(`/api/v2/admin-to/${admin2_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
       .end((err, res)=> {
         res.should.have.status(401);
@@ -260,13 +227,10 @@ describe('AdminController /PATCH admin to user', ()=> {
 
 
   it('Should verify invalid token', (done)=> {
-    const wrongToken = 'ciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3ROYW1lIjoicHJvZG8iLCJsYXN0TmFtZSI6Imtha2EiLCJlbWFpbCI6InBAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkVFcyYmxUWnYzZ1FiNldNRXJZSmtULi5YSUhrendnZW5GWm1NTVlXVjZwaFRFd1dGUjhqbk8iLCJhZGRyZXNzIjoiYWRkcmVzcyIsImJpbyI6ImJpbyIsIm9jY3VwYXRpb24iOiJvY2N1cCIsImV4cGVydGlzZSI6ImV4cHJ0IiwidHlwZSI6Im5vcm1hbCIsImlhdCI6MTU2NjQ2NjQyNiwiZXhwIjoxNTY2ODEyMDI2fQ.hBkHlelgfCp1qnRVhgvCPFcm16camwv0mZNxFGhHkmw';
-    const { id: admin2_user_id } = user_admin2;
+    request(server).patch(`/api/v2/admin-to/${user_admin2.id}`)
 
-    request(server).patch(`/api/v2/admin-to/${admin2_user_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', wrongToken)
+      .set('token', wrong_token)
       .end((err, res)=> {
         res.body.status.should.be.eql(500);
         res.body.error.should.be.a('string').eql('invalid token');
@@ -276,13 +240,10 @@ describe('AdminController /PATCH admin to user', ()=> {
 
 
   it('Should verify malformed token', (done)=> {
-    const malformed_token = 'badToken';
-    const { id: admin2_user_id } = user_admin2;
+    request(server).patch(`/api/v2/admin-to/${user_admin2.id}`)
 
-    request(server).patch(`/api/v2/admin-to/${admin2_user_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', malformed_token)
+      .set('token', 'badToken')
       .end((err, res)=> {
         res.body.status.should.be.a('number').eql(500);
         res.body.error.should.be.a('string').eql('jwt malformed');
@@ -294,13 +255,10 @@ describe('AdminController /PATCH admin to user', ()=> {
 
 describe('AdminController /PATCH user to mentor', ()=> {
   it('Should change a normal user to mentor', (done)=> {
-    const { id: normal_user_id } = user_normal;
-    const { token: user_admin_token } = user_admin1;
+    request(server).patch(`/api/v2/user/${user_normal.id}`)
 
-    request(server).patch(`/api/v2/user/${normal_user_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', user_admin_token)
+      .set('token', user_admin1.token)
       .end((err, res)=> {
         created_mentor = { ...created_mentor, ...res.body.data };
         res.should.have.status(200);
@@ -315,7 +273,7 @@ describe('AdminController /PATCH user to mentor', ()=> {
     const { id: normal_user_id } = user_normal;
 
     request(server).patch(`/api/v2/user/${normal_user_id}`)
-      .set('Content-type', 'application/json')
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .end((err, res)=> {
         res.should.have.status(401);
@@ -326,15 +284,10 @@ describe('AdminController /PATCH user to mentor', ()=> {
 
 
   it('Should verify invalid token', (done)=> {
-    const { id: normal_user_id } = user_normal;
+    request(server).patch(`/api/v2/user/${user_normal.id}`)
 
-    const wrongToken = 'ciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3ROYW1lIjoicHJvZG8iLCJsYXN0TmFtZSI6Imtha2EiLCJlbWFpbCI6InBAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkVFcyYmxUWnYzZ1FiNldNRXJZSmtULi5YSUhrendnZW5GWm1NTVlXVjZwaFRFd1dGUjhqbk8iLCJhZGRyZXNzIjoiYWRkcmVzcyIsImJpbyI6ImJpbyIsIm9jY3VwYXRpb24iOiJvY2N1cCIsImV4cGVydGlzZSI6ImV4cHJ0IiwidHlwZSI6Im5vcm1hbCIsImlhdCI6MTU2NjQ2NjQyNiwiZXhwIjoxNTY2ODEyMDI2fQ.hBkHlelgfCp1qnRVhgvCPFcm16camwv0mZNxFGhHkmw';
-
-
-    request(server).patch(`/api/v2/user/${normal_user_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', wrongToken)
+      .set('token', wrong_token)
       .end((err, res)=> {
         res.body.status.should.be.eql(500);
         res.body.error.should.be.a('string').eql('invalid token');
@@ -344,13 +297,10 @@ describe('AdminController /PATCH user to mentor', ()=> {
 
 
   it('Should verify malformed token', (done)=> {
-    const { id: normal_user_id } = user_normal;
-    const malformed_token = 'badToken';
+    request(server).patch(`/api/v2/user/${user_normal.id}`)
 
-    request(server).patch(`/api/v2/user/${normal_user_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', malformed_token)
+      .set('token', 'badToken')
       .end((err, res)=> {
         res.body.status.should.be.a('number').eql(500);
         res.body.error.should.be.a('string').eql('jwt malformed');
@@ -359,14 +309,11 @@ describe('AdminController /PATCH user to mentor', ()=> {
   });
 
 
-  it('Should return an access forbiden if the user who changes is not an admin or does not have email:p@gmail.com', (done)=> {
-    const { id: normal_user_id } = user_normal;
-    const { token: user_noAdmin_token } = notAdmin_user;
+  it('Should return an access forbiden if the user who changes is not an admin ', (done)=> {
+    request(server).patch(`/api/v2/user/${user_normal.id}`)
 
-    request(server).patch(`/api/v2/user/${normal_user_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', user_noAdmin_token)
+      .set('token', notAdmin_user.token)
       .end((err, res)=> {
         res.should.have.status(403);
         res.body.error.should.be.a('string').eql('Access forbiden,reserved for admin');
@@ -376,13 +323,10 @@ describe('AdminController /PATCH user to mentor', ()=> {
 
 
   it('Should return status:400 if the id of the user to be changed was not found', (done)=> {
-    const wrongId = 450;
-    const { token: user_admin_token } = user_admin1;
+    request(server).patch('/api/v2/user/450')
 
-    request(server).patch(`/api/v2/user/${wrongId}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', user_admin_token)
+      .set('token', user_admin1.token)
       .end((err, res)=> {
         res.should.have.status(400);
         res.body.error.should.be.a('string').eql('user with the sent id not found');
@@ -394,13 +338,10 @@ describe('AdminController /PATCH user to mentor', ()=> {
 
 describe('AdminController /PATCH mentor to user', ()=> {
   it('Should change a mentor to normal user', (done)=> {
-    const { id: mentor_user_id } = created_mentor;
-    const { token: user_admin_token } = user_admin1;
+    request(server).patch(`/api/v2/mentor/${created_mentor.id}`)
 
-    request(server).patch(`/api/v2/mentor/${mentor_user_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', user_admin_token)
+      .set('token', user_admin1.token)
       .end((err, res)=> {
         res.should.have.status(200);
         res.body.data.should.have.property('type').eql('user');
@@ -410,29 +351,22 @@ describe('AdminController /PATCH mentor to user', ()=> {
 
 
   it('Should return status 401 if the token has been not sent', (done)=> {
-    const { id: normal_user_id } = user_normal;
+    request(server).patch(`/api/v2/admin-to/${user_admin2.id}`)
 
-    request(server).patch(`/api/v2/mentor/${normal_user_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
       .end((err, res)=> {
         res.should.have.status(401);
-        res.body.error.should.be.a('string').eql('Anauthorized,please login first');
+        res.body.should.have.property('error').eql('Anauthorized,please login first');
         done();
       });
   });
 
 
   it('Should verify invalid token', (done)=> {
-    const { id: normal_user_id } = user_normal;
+    request(server).patch(`/api/v2/user/${user_normal.id}`)
 
-    const wrongToken = 'ciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3ROYW1lIjoicHJvZG8iLCJsYXN0TmFtZSI6Imtha2EiLCJlbWFpbCI6InBAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkVFcyYmxUWnYzZ1FiNldNRXJZSmtULi5YSUhrendnZW5GWm1NTVlXVjZwaFRFd1dGUjhqbk8iLCJhZGRyZXNzIjoiYWRkcmVzcyIsImJpbyI6ImJpbyIsIm9jY3VwYXRpb24iOiJvY2N1cCIsImV4cGVydGlzZSI6ImV4cHJ0IiwidHlwZSI6Im5vcm1hbCIsImlhdCI6MTU2NjQ2NjQyNiwiZXhwIjoxNTY2ODEyMDI2fQ.hBkHlelgfCp1qnRVhgvCPFcm16camwv0mZNxFGhHkmw';
-
-
-    request(server).patch(`/api/v2/mentor/${normal_user_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', wrongToken)
+      .set('token', wrong_token)
       .end((err, res)=> {
         res.body.status.should.be.eql(500);
         res.body.error.should.be.a('string').eql('invalid token');
@@ -441,14 +375,11 @@ describe('AdminController /PATCH mentor to user', ()=> {
   });
 
 
-  it('Should verify malformed token', (done)=> {
-    const { id: normal_user_id } = user_normal;
-    const malformed_token = 'badToken';
+it('Should verify malformed token', (done)=> {
+    request(server).patch(`/api/v2/user/${user_normal.id}`)
 
-    request(server).patch(`/api/v2/mentor/${normal_user_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', malformed_token)
+      .set('token', 'badToken')
       .end((err, res)=> {
         res.body.status.should.be.a('number').eql(500);
         res.body.error.should.be.a('string').eql('jwt malformed');
@@ -457,14 +388,11 @@ describe('AdminController /PATCH mentor to user', ()=> {
   });
 
 
-  it('Should return an access forbiden if the user who changes is not an admin or does not have email:p@gmail.com', (done)=> {
-    const { id: normal_user_id } = user_normal;
-    const { token: user_noAdmin_token } = notAdmin_user;
+  it('Should return an access forbiden if the user who changes is not an admin', (done)=> {
+    request(server).patch(`/api/v2/mentor/${user_normal.id}`)
 
-    request(server).patch(`/api/v2/mentor/${normal_user_id}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', user_noAdmin_token)
+      .set('token', notAdmin_user.token)
       .end((err, res)=> {
         res.should.have.status(403);
         res.body.error.should.be.a('string').eql('Access forbiden,reserved for admin');
@@ -474,13 +402,10 @@ describe('AdminController /PATCH mentor to user', ()=> {
 
 
   it('Should return status:400 if the id of the mentor to be changed was not found', (done)=> {
-    const wrongId = 450;
-    const { token: user_admin_token } = user_admin1;
+    request(server).patch(`/api/v2/mentor/450`)
 
-    request(server).patch(`/api/v2/mentor/${wrongId}`)
-      .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', user_admin_token)
+      .set('token', user_admin1.token)
       .end((err, res)=> {
         res.should.have.status(400);
         res.body.error.should.be.a('string').eql('user with the sent id not found');

--- a/server/v2/test/2admin.test.js
+++ b/server/v2/test/2admin.test.js
@@ -189,7 +189,6 @@ describe('AdminController /PATCH admin to user', ()=> {
   });
 
   it('Should return a code status 400 if corresponding user of the  sent user id is not found', (done)=> {
-
     request(server).patch('/api/v2/admin-to/10001')
 
       .set('Content-type', 'application/x-www-form-urlencoded')
@@ -205,7 +204,7 @@ describe('AdminController /PATCH admin to user', ()=> {
     request(server).patch(`/api/v2/admin-to/${user_admin2.id}`)
 
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token',notAdmin_user.token)
+      .set('token', notAdmin_user.token)
       .end((err, res)=> {
         res.should.have.status(403);
         res.body.error.should.be.a('string').eql('Access forbiden,reserved for admin');
@@ -375,7 +374,7 @@ describe('AdminController /PATCH mentor to user', ()=> {
   });
 
 
-it('Should verify malformed token', (done)=> {
+  it('Should verify malformed token', (done)=> {
     request(server).patch(`/api/v2/user/${user_normal.id}`)
 
       .set('Content-type', 'application/x-www-form-urlencoded')
@@ -402,7 +401,7 @@ it('Should verify malformed token', (done)=> {
 
 
   it('Should return status:400 if the id of the mentor to be changed was not found', (done)=> {
-    request(server).patch(`/api/v2/mentor/450`)
+    request(server).patch('/api/v2/mentor/450')
 
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', user_admin1.token)

--- a/server/v2/test/3users.test.js
+++ b/server/v2/test/3users.test.js
@@ -2,7 +2,7 @@
 import { should, use, request } from 'chai';
 import chaiHttp from 'chai-http';
 import server from '../../../index';
-import data from './data';
+import data from './mockData';
 
 should();
 use(chaiHttp);
@@ -11,6 +11,7 @@ let {
   user2,
   user3,
 } = data.users;
+const { wrong_token } = data.other_token;
 
 let user_admin;
 let user_mentor;
@@ -38,12 +39,10 @@ describe('UserController /GET all mentors', ()=> {
 
 
   it('Should return an array containing object of all mentors', (done)=> {
-    const { token } = user_mentor;
-
     request(server).get('/api/v2/mentors')
       .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', token)
+      .set('token', user_mentor.token)
       .end((err, res)=> {
         res.should.have.status(200);
         res.body.data.should.be.an('array');
@@ -65,12 +64,10 @@ describe('UserController /GET all mentors', ()=> {
 
 
   it('Should verify invalid token', (done)=> {
-    const wrongToken = 'ciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3ROYW1lIjoicHJvZG8iLCJsYXN0TmFtZSI6Imtha2EiLCJlbWFpbCI6InBAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkVFcyYmxUWnYzZ1FiNldNRXJZSmtULi5YSUhrendnZW5GWm1NTVlXVjZwaFRFd1dGUjhqbk8iLCJhZGRyZXNzIjoiYWRkcmVzcyIsImJpbyI6ImJpbyIsIm9jY3VwYXRpb24iOiJvY2N1cCIsImV4cGVydGlzZSI6ImV4cHJ0IiwidHlwZSI6Im5vcm1hbCIsImlhdCI6MTU2NjQ2NjQyNiwiZXhwIjoxNTY2ODEyMDI2fQ.hBkHlelgfCp1qnRVhgvCPFcm16camwv0mZNxFGhHkmw';
-
     request(server).get('/api/v2/mentors')
       .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', wrongToken)
+      .set('token', wrong_token)
       .end((err, res)=> {
         res.body.status.should.be.a('number').eql(500);
         res.body.error.should.be.a('string').eql('invalid token');
@@ -97,12 +94,10 @@ describe('UserController /GET all mentors', ()=> {
 
 describe('UserController /GET specific mentor', ()=> {
   it('Should return an object of a specific mentor', (done)=> {
-    const { token, id: mentorId } = user_mentor;
-
-    request(server).get(`/api/v2/mentors/${mentorId}`)
+    request(server).get(`/api/v2/mentors/${user_mentor.id}`)
       .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', token)
+      .set('token', user_mentor.token)
       .end((err, res)=> {
         res.should.have.status(200);
         res.body.data.should.be.an('object');
@@ -111,13 +106,10 @@ describe('UserController /GET specific mentor', ()=> {
   });
 
   it('Should return a status code 412 if the mentor was not found', (done)=> {
-    const { token } = user_mentor;
-    const wrong_mentor_id = 467346874;
-
-    request(server).get(`/api/v2/mentors/${wrong_mentor_id}`)
+    request(server).get(`/api/v2/mentors/467346874`)
       .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', token)
+      .set('token', user_mentor.token)
       .end((err, res)=> {
         res.should.have.status(412);
         res.body.error.should.be.an('string').eql('Mentor not found');
@@ -127,7 +119,7 @@ describe('UserController /GET specific mentor', ()=> {
 
 
   it('Should return status 401 if the token has been not sent', (done)=> {
-    request(server).get('/api/v2/mentors')
+    request(server).get(`/api/v2/mentors/${user_mentor.id}`)
       .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
       .end((err, res)=> {
@@ -139,12 +131,10 @@ describe('UserController /GET specific mentor', ()=> {
 
 
   it('Should verify invalid token', (done)=> {
-    const wrongToken = 'ciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3ROYW1lIjoicHJvZG8iLCJsYXN0TmFtZSI6Imtha2EiLCJlbWFpbCI6InBAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkVFcyYmxUWnYzZ1FiNldNRXJZSmtULi5YSUhrendnZW5GWm1NTVlXVjZwaFRFd1dGUjhqbk8iLCJhZGRyZXNzIjoiYWRkcmVzcyIsImJpbyI6ImJpbyIsIm9jY3VwYXRpb24iOiJvY2N1cCIsImV4cGVydGlzZSI6ImV4cHJ0IiwidHlwZSI6Im5vcm1hbCIsImlhdCI6MTU2NjQ2NjQyNiwiZXhwIjoxNTY2ODEyMDI2fQ.hBkHlelgfCp1qnRVhgvCPFcm16camwv0mZNxFGhHkmw';
-
     request(server).get('/api/v2/mentors')
       .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', wrongToken)
+      .set('token', wrong_token)
       .end((err, res)=> {
         res.body.status.should.be.a('number').eql(500);
         res.body.error.should.be.a('string').eql('invalid token');
@@ -154,12 +144,10 @@ describe('UserController /GET specific mentor', ()=> {
 
 
   it('Should verify malformed token', (done)=> {
-    const malformed_token = 'badToken';
-
     request(server).get('/api/v2/mentors')
       .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
-      .set('token', malformed_token)
+      .set('token', 'badToken')
       .end((err, res)=> {
         res.body.status.should.be.a('number').eql(500);
         res.body.error.should.be.a('string').eql('jwt malformed');

--- a/server/v2/test/3users.test.js
+++ b/server/v2/test/3users.test.js
@@ -106,7 +106,7 @@ describe('UserController /GET specific mentor', ()=> {
   });
 
   it('Should return a status code 412 if the mentor was not found', (done)=> {
-    request(server).get(`/api/v2/mentors/467346874`)
+    request(server).get('/api/v2/mentors/467346874')
       .set('Content-type', 'application/json')
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', user_mentor.token)

--- a/server/v2/test/4session.test.js
+++ b/server/v2/test/4session.test.js
@@ -2,7 +2,8 @@ import { should, use, request } from 'chai';
 import chaiHttp from 'chai-http';
 import server from '../../../index';
 import data from './mockData';
-const { other_token:{ wrong_token }, sessions } = data;
+
+const { other_token: { wrong_token }, sessions } = data;
 
 should();
 use(chaiHttp);
@@ -26,7 +27,7 @@ let unconcern_mentor;
 describe('SessionController /POST sessions', ()=> {
   before((done)=> {
     request(server).post('/api/v2/auth/signin')
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .send(user2)
       .then((res)=> {
@@ -34,7 +35,7 @@ describe('SessionController /POST sessions', ()=> {
       });
 
     request(server).post('/api/v2/auth/signin')
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .send(user1)
       .then((res)=> {
@@ -42,7 +43,7 @@ describe('SessionController /POST sessions', ()=> {
       });
 
     request(server).post('/api/v2/auth/signin')
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .send(user3)
       .then((res)=> {
@@ -51,7 +52,7 @@ describe('SessionController /POST sessions', ()=> {
 
 
     request(server).post('/api/v2/auth/signin')
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .send(user4)
       .then((res)=> {
@@ -59,7 +60,7 @@ describe('SessionController /POST sessions', ()=> {
       });
 
     request(server).post('/api/v2/auth/signup')
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .send(user5)
       .then((res)=> {
@@ -71,7 +72,7 @@ describe('SessionController /POST sessions', ()=> {
 
   it('Should create a mentorship session', (done)=> {
     request(server).post('/api/v2/sessions')
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', user_mentee.token)
       .send(sessions.data(user_mentor.id))
@@ -86,7 +87,7 @@ describe('SessionController /POST sessions', ()=> {
 
   it('Should return 412 code status if the mentorId is not found', (done)=> {
     request(server).post('/api/v2/sessions')
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', user_mentee.token)
       .send(sessions.data(40))
@@ -100,7 +101,7 @@ describe('SessionController /POST sessions', ()=> {
 
   it('Should return 400 code status when the recorded input are invalid', (done)=> {
     request(server).post('/api/v2/sessions')
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', user_mentee.token)
       .send(sessions.invalid_datadata(user_mentor.id))
@@ -114,7 +115,7 @@ describe('SessionController /POST sessions', ()=> {
 
   it('Should return status 401 if the token has been not sent', (done)=> {
     request(server).post('/api/v2/sessions')
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .end((err, res)=> {
         res.should.have.status(401);
@@ -126,7 +127,7 @@ describe('SessionController /POST sessions', ()=> {
 
   it('Should verify invalid token', (done)=> {
     request(server).post('/api/v2/sessions')
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', wrong_token)
       .end((err, res)=> {
@@ -139,7 +140,7 @@ describe('SessionController /POST sessions', ()=> {
 
   it('Should verify malformed token', (done)=> {
     request(server).post('/api/v2/sessions')
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', 'badToken')
       .end((err, res)=> {
@@ -154,7 +155,7 @@ describe('SessionController /POST sessions', ()=> {
 describe('SessionController /PATCH: accept session', ()=> {
   before((done)=> {
     request(server).patch(`/api/v2/user/${unconcern_mentor.id}`)
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', user_admin.token)
       .then((res)=> {
@@ -165,7 +166,7 @@ describe('SessionController /PATCH: accept session', ()=> {
 
   it(('Should login the unconcern mentor to update his payload in jwt'), (done)=> {
     request(server).post('/api/v2/auth/signin')
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .send(unconcern_mentor)
       .end((err, res)=> {
@@ -177,7 +178,7 @@ describe('SessionController /PATCH: accept session', ()=> {
 
   it('Should return a status code 200 when mentor accept a session', (done)=> {
     request(server).patch(`/api/v2/sessions/${created_session.id}/accept`)
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', user_mentor.token)
       .end((err, res)=> {
@@ -194,7 +195,7 @@ describe('SessionController /PATCH: accept session', ()=> {
 
   it('Should return a status code 400 when session with sent sessionId is not found', (done)=> {
     request(server).patch('/api/v2/sessions/312/accept')
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', user_mentor.token)
       .end((err, res)=> {
@@ -208,7 +209,7 @@ describe('SessionController /PATCH: accept session', ()=> {
 
   it('Should return a status code 400 when an unconcern mentor want to accept a mentorship request', (done)=> {
     request(server).patch(`/api/v2/sessions/${created_session.id}/accept`)
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', unconcern_mentor.token)
       .end((err, res)=> {
@@ -222,7 +223,7 @@ describe('SessionController /PATCH: accept session', ()=> {
 
   it('Should return a status code 400 when a mentor is trying to repeat the same operation', (done)=> {
     request(server).patch(`/api/v2/sessions/${created_session.id}/accept`)
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', user_mentor.token)
       .end((err, res)=> {
@@ -237,7 +238,7 @@ describe('SessionController /PATCH: accept session', ()=> {
 
   it('Should return a status code 403 when an auth user is not a mentor', (done)=> {
     request(server).patch(`/api/v2/sessions/${created_session.id}/accept`)
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', user_3.token)
       .end((err, res)=> {
@@ -252,7 +253,7 @@ describe('SessionController /PATCH: accept session', ()=> {
 
   it('Should return status 401 if the token has been not sent', (done)=> {
     request(server).patch(`/api/v2/sessions/${created_session.id}/accept`)
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .end((err, res)=> {
         res.should.have.status(401);
@@ -264,7 +265,7 @@ describe('SessionController /PATCH: accept session', ()=> {
 
   it('Should verify invalid token', (done)=> {
     request(server).patch(`/api/v2/sessions/${created_session.id}/accept`)
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', wrong_token)
       .end((err, res)=> {
@@ -277,7 +278,7 @@ describe('SessionController /PATCH: accept session', ()=> {
 
   it('Should verify malformed token', (done)=> {
     request(server).patch(`/api/v2/sessions/${created_session.id}/accept`)
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', 'badToken')
       .end((err, res)=> {
@@ -292,7 +293,7 @@ describe('SessionController /PATCH: accept session', ()=> {
 describe('SessionController /PATCH reject session', ()=> {
   before((done)=> {
     request(server).post('/api/v2/sessions')
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', user_mentee.token)
       .send(sessions.reject_session(user_mentor.id))
@@ -305,7 +306,7 @@ describe('SessionController /PATCH reject session', ()=> {
 
   it('Should return a status code 200 when mentor reject a session', (done)=> {
     request(server).patch(`/api/v2/sessions/${created_session.id}/reject`)
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', user_mentor.token)
       .end((err, res)=> {
@@ -322,7 +323,7 @@ describe('SessionController /PATCH reject session', ()=> {
 
   it('Should return a status code 400 when session with sent sessionId is not found', (done)=> {
     request(server).patch('/api/v2/sessions/32/reject')
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', user_mentor.token)
       .end((err, res)=> {
@@ -336,7 +337,7 @@ describe('SessionController /PATCH reject session', ()=> {
 
   it('Should return a status code 400 when an unconcern mentor want to reject a mentorship request', (done)=> {
     request(server).patch(`/api/v2/sessions/${created_session.id}/reject`)
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', unconcern_mentor.token)
       .end((err, res)=> {
@@ -350,7 +351,7 @@ describe('SessionController /PATCH reject session', ()=> {
 
   it('Should return a status code 400 when a mentor is trying to repeat the same operation', (done)=> {
     request(server).patch(`/api/v2/sessions/${created_session.id}/reject`)
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', user_mentor.token)
       .end((err, res)=> {
@@ -365,7 +366,7 @@ describe('SessionController /PATCH reject session', ()=> {
 
   it('Should return a status code 403 when an auth user is not a mentor', (done)=> {
     request(server).patch(`/api/v2/sessions/${created_session.id}/reject`)
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', user_3.token)
       .end((err, res)=> {
@@ -380,7 +381,7 @@ describe('SessionController /PATCH reject session', ()=> {
 
   it('Should return status 401 if the token has been not sent', (done)=> {
     request(server).patch(`/api/v2/sessions/${created_session.id}/reject`)
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .end((err, res)=> {
         res.should.have.status(401);
@@ -392,7 +393,7 @@ describe('SessionController /PATCH reject session', ()=> {
 
   it('Should verify invalid token', (done)=> {
     request(server).patch(`/api/v2/sessions/${created_session.id}/reject`)
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', wrong_token)
       .end((err, res)=> {
@@ -405,7 +406,7 @@ describe('SessionController /PATCH reject session', ()=> {
 
   it('Should verify malformed token', (done)=> {
     request(server).patch(`/api/v2/sessions/${created_session.id}/reject`)
-      
+
       .set('Content-type', 'application/x-www-form-urlencoded')
       .set('token', 'badToken')
       .end((err, res)=> {

--- a/server/v2/test/mockData.js
+++ b/server/v2/test/mockData.js
@@ -11,6 +11,7 @@ export default {
       expertise: 'web development',
       occupation: 'software developer',
       address: 'kigali',
+      token:'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZW1haWwiOiJ1c2VyMUBnbWFpbC5jb20iLCJpc19hZG1pbiI6ZmFsc2UsImlhdCI6MTU2ODEyMTg2NSwiZXhwIjoxNTk5Njc5NDY1fQ.fQYN5gAH3Jg_s4_-modlSqR41OPVlsK_KeM7dBJRMOE',
     },
     user2: {
       id: 2,
@@ -24,6 +25,7 @@ export default {
       address: 'kigali',
       unexpected1: 'unexpected1',
       unexpected2: 'unexpected2',
+
     },
     user3: {
       id: 3,
@@ -97,24 +99,21 @@ export default {
       return {
         questions: 'questions here',
         mentor_id,
-        start_date: '12/12/2019',
-        end_date: '20/03/2020',
+        date: '12/12/2019',
       };
     },
     invalid_datadata:(mentor_id)=>{
       return {
         question: 'questions here',
         mentor_id,
-        start_date: '12/12/2019',
-        end_date: '20/03/2020',
+        date: '12/12/2019',
       };
     },
     reject_session: (mentor_id)=> {
       return {
         questions: 'questions2 here',
         mentor_id,
-        start_date: '12/12/2019',
-        end_date: '20/03/2020',
+        date: '12/12/2019',
       };
     }
   }

--- a/server/v2/test/mockData.js
+++ b/server/v2/test/mockData.js
@@ -2,6 +2,7 @@ export default {
 
   users: {
     user1: {
+      id: 1,
       firstname: 'user1',
       lastname: 'kaka',
       email: 'user1@gmail.com',
@@ -12,6 +13,7 @@ export default {
       address: 'kigali',
     },
     user2: {
+      id: 2,
       firstname: 'user2',
       lastname: 'bro',
       email: 'user2@gmail.com',
@@ -20,8 +22,11 @@ export default {
       expertise: 'web development',
       occupation: 'software developer',
       address: 'kigali',
+      unexpected1: 'unexpected1',
+      unexpected2: 'unexpected2',
     },
     user3: {
+      id: 3,
       firstname: 'user3',
       lastname: 'amakuru',
       email: 'user3@gmail.com',
@@ -32,6 +37,7 @@ export default {
       address: 'kigali',
     },
     user4: {
+      id: 4,
       firstname: 'user4',
       lastname: 'amakuru',
       email: 'user4@gmail.com',
@@ -42,6 +48,7 @@ export default {
       address: 'kigali',
     },
     user5: {
+      id: 5,
       firstname: 'user5',
       lastname: 'doctor',
       email: 'user5@gmail.com',
@@ -60,10 +67,18 @@ export default {
       expertise: 'web development',
       occupation: 'software developer',
       address: 'kigali',
-    }
+    },
+    wrong_login_email: {
+      email: 'ko45o@gmail.com',
+      password: '12345678',
+    },
+    wrong_login_password: {
+      email: 'd1@gmail.com',
+      password: '45678',
+    },
   },
   review_auth: {
-    
+
     score_info: {
       score: 3,
       remark: 'Every thing was good, but and then ,so i conclude',
@@ -74,6 +89,35 @@ export default {
 
     },
   },
+  other_token: {
+    wrong_token: 'ciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZmlyc3ROYW1lIjoicHJvZG8iLCJsYXN0TmFtZSI6Imtha2EiLCJlbWFpbCI6InBAZ21haWwuY29tIiwicGFzc3dvcmQiOiIkMmIkMTAkVFcyYmxUWnYzZ1FiNldNRXJZSmtULi5YSUhrendnZW5GWm1NTVlXVjZwaFRFd1dGUjhqbk8iLCJhZGRyZXNzIjoiYWRkcmVzcyIsImJpbyI6ImJpbyIsIm9jY3VwYXRpb24iOiJvY2N1cCIsImV4cGVydGlzZSI6ImV4cHJ0IiwidHlwZSI6Im5vcm1hbCIsImlhdCI6MTU2NjQ2NjQyNiwiZXhwIjoxNTY2ODEyMDI2fQ.hBkHlelgfCp1qnRVhgvCPFcm16camwv0mZNxFGhHkmw',
+  },
+  sessions: {
+    data:(mentor_id)=>{
+      return {
+        questions: 'questions here',
+        mentor_id,
+        start_date: '12/12/2019',
+        end_date: '20/03/2020',
+      };
+    },
+    invalid_datadata:(mentor_id)=>{
+      return {
+        question: 'questions here',
+        mentor_id,
+        start_date: '12/12/2019',
+        end_date: '20/03/2020',
+      };
+    },
+    reject_session: (mentor_id)=> {
+      return {
+        questions: 'questions2 here',
+        mentor_id,
+        start_date: '12/12/2019',
+        end_date: '20/03/2020',
+      };
+    }
+  }
 
 
 };


### PR DESCRIPTION
#### What does this PR do?
It fixes some common mistakes of endpoints
#### Description of Task to be completed?
- Create a mockData file for unit tests
- remain with token only in login/signup response
- return session payload with session_id 
- make dates visible
- remove start_date and end_date when creating a session

#### What are the relevant pivotal tracker stories?
[#168401226](https://www.pivotaltracker.com/story/show/168401226)
#### Screenshots (if appropriate)
###### remain with token only in login/signup response
![login_with_token](https://user-images.githubusercontent.com/30261670/64638112-7555e800-d405-11e9-8800-cff11dd69490.png)
###### return session payload with session_id  / remove start_date and end_date
![session_with_session_id](https://user-images.githubusercontent.com/30261670/64638143-843c9a80-d405-11e9-8b1e-fbb2ed3da625.png)
###### make dates visible (list of all mentors)
![list_mentor_clear_date](https://user-images.githubusercontent.com/30261670/64638229-ad5d2b00-d405-11e9-89a9-51efb19d94d9.png)
