### PR TITLE
 #168425946 fix response bug 

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "NODE_ENV=production babel-node index.js",
     "dev": "NODE_ENV=dev nodemon --exec babel-node  ./index.js",
-    "test": "NODE_ENV=test nyc mocha --exit --timeout 150000 --require @babel/register --require babel-polyfill ./server/**/*.test.js",
+    "test": "NODE_ENV=test nyc mocha --exit --timeout 5000 --require @babel/register --require babel-polyfill ./server/**/*.test.js",
     "test_ch1": "mocha --exit --timeout 5000 --require @babel/register --require babel-polyfill ./server/**/*.test.js",
     "coverage": "nyc --reporter=lcov --reporter=text-lcov npm test | coveralls",
     "migrate": "NODE_ENV=production babel-node ./server/v2/models/table_generator.js",

--- a/server/v2/controllers/UserController.js
+++ b/server/v2/controllers/UserController.js
@@ -1,18 +1,19 @@
 import User from '../models/User';
 import GeneralHelper from '../helpers/general';
 
-const { response, arrange_date } = GeneralHelper;
+const { response, arrange_date, change_attribute } = GeneralHelper;
 
-const dataToHide = ['role', 'type'];
+const dataToHide = ['is_admin', 'type'];
 
 class UserController {
   static async mentors(req, res, next) {
     try {
       let mentors = await User.findWhere('type', 'mentor');
 
-      mentors = arrange_date(mentors);
+      mentors = change_attribute(mentors, { id: 'mentor_id' });
 
-      return response(res, 200, 'List of mentors', mentors, [...User.dataToHide, ...dataToHide]);
+
+      return response(res, 200, 'List of mentors', arrange_date(mentors), [...User.dataToHide, ...dataToHide]);
     } catch (error) {
       return next(error);
     }
@@ -24,8 +25,9 @@ class UserController {
     try {
       let [mentor] = await User.customQuery('WHERE id=$1 AND type=$2', [mentorId, 'mentor']);
 
-      mentor = arrange_date(mentor);
-      if (mentor) return response(res, 200, 'A specific mentor', mentor, [...User.dataToHide, ...dataToHide]);
+      mentor = change_attribute(mentor, { id: 'mentor_id' });
+
+      if (mentor) return response(res, 200, 'A specific mentor', arrange_date(mentor), [...User.dataToHide, ...dataToHide]);
       return response(res, 412, 'Mentor not found');
     } catch (error) {
       return next(error);

--- a/server/v2/helpers/db_Helper.js
+++ b/server/v2/helpers/db_Helper.js
@@ -1,5 +1,7 @@
 import moment from 'moment';
 
+const { NODE_ENV } = process.env;
+
 class DbHelper {
   static prepareData(data) {
     const keys = Object.keys(data);
@@ -55,6 +57,7 @@ class DbHelper {
           const replaceWith = attributes[attrToReplace];
 
           item[replaceWith] = item[attrToReplace];
+          if (NODE_ENV !== 'test') { delete item[attrToReplace]; }
         }
         return attrToReplace;
       });
@@ -74,6 +77,7 @@ class DbHelper {
         const replaceWith = attributes[attrToReplace];
 
         data[replaceWith] = data[attrToReplace];
+        if (NODE_ENV !== 'test') { delete data[attrToReplace]; }
       }
       return attrToReplace;
     });

--- a/server/v2/helpers/general.js
+++ b/server/v2/helpers/general.js
@@ -49,17 +49,26 @@ class General {
   }
 
 
-  static response(res, status, msg, data = {}, dataToRemove) {
-    if (status === 200 || status === 201) {
-      if (dataToRemove) { removeDataToHide(data, dataToRemove); }
-
+  static successResp(res, status, msg, data) {
+    if (data) {
       return res.status(status).json({
         status,
         message: msg,
         data,
       });
     }
+    return res.status(status).json({
+      status,
+      message: msg,
+    });
+  }
 
+
+  static response(res, status, msg, data, dataToRemove) {
+    if (status === 200 || status === 201) {
+      if (dataToRemove) { removeDataToHide(data, dataToRemove); }
+      return General.successResp(res, status, msg, data);
+    }
 
     return res.status(status).json({
       status,

--- a/server/v2/middleware/dataExist.js
+++ b/server/v2/middleware/dataExist.js
@@ -71,7 +71,7 @@ export default {
 
       const [review] = await Review.findWhere('session_id', sessionId);
 
-      if (review) return response(res, 400, 'Session has another review');
+      if (review) return response(res, 400, 'You have already reviewed this session');
 
       return next();
     } catch (e) {

--- a/server/v2/test/5review.test.js
+++ b/server/v2/test/5review.test.js
@@ -90,7 +90,7 @@ describe('ReviewController /POST review', ()=> {
       .end((err, res)=> {
         res.should.have.status(400);
         res.should.have.status(400);
-        res.body.should.have.property('error').eql('Session has another review');
+        res.body.should.have.property('error').eql('You have already reviewed this session');
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?
Remove common mistakes of response payload
#### Description of Task to be completed?
- avoid send a respond with like :  id and session_id
- Change the error message when create a review twice
- remove data property in case is empty

#### What are the relevant pivotal tracker stories?
[ #168425946](https://www.pivotaltracker.com/story/show/168425946)
#### Screenshots (if appropriate)
###### avoid send a respond with like :  id and session_id
![create_review](https://user-images.githubusercontent.com/30261670/64691360-ca8c0b00-d492-11e9-9306-69f4616c4b0d.png)

###### Change the error message when create a review twice
![repeat_review](https://user-images.githubusercontent.com/30261670/64691474-03c47b00-d493-11e9-94f8-dc1b35f27a75.png)

###### remove data property in case is empty
![remove_data_on_delete](https://user-images.githubusercontent.com/30261670/64691489-0a52f280-d493-11e9-931b-b1b4390e9a81.png)


